### PR TITLE
Add support for eXeLearning (.elp) files

### DIFF
--- a/src/Media/Renderer/LearningObject.php
+++ b/src/Media/Renderer/LearningObject.php
@@ -14,7 +14,7 @@ class LearningObject implements RendererInterface
 
         $html = '<div class="learning-object-container">';
         
-        if (!empty($learningObjectData) && isset($learningObjectData['type']) && $learningObjectData['type'] === 'SCORM') {
+        if (!empty($learningObjectData) && isset($learningObjectData['type']) && in_array($learningObjectData['type'], ['SCORM', 'eXeLearning'])) {
             // Use partial for SCORM packages
             $html .= $view->partial('common/scorm-package', [
                 'learningObjectData' => $learningObjectData,


### PR DESCRIPTION
This PR extends the module to support eXeLearning files (.elp), which are widely used for authoring learning content. The ingester now recognizes .elp files and processes them according to their internal structure and version.

# Details

## eXeLearning 3.x support:
- If the .elp file contains both content.xml and index.html at the root, it is treated as a SCORM-like package.
- The package is extracted and visualized using index.html as the entry point.
## eXeLearning 2.9 (and earlier) handling:
- If the .elp file contains contentv3.xml and does not have index.html, the upload is rejected.
- The user receives a clear message recommending to open the package with eXeLearning 3.x and re-export it.
SCORM packages continue to work as before.
- The allowed file extensions and MIME types have been updated to accept .elp files.

# Motivation
eXeLearning is a popular tool for creating educational content, especially in Spanish-speaking contexts. Supporting .elp files improves the module’s usability for a wider range of users and learning object sources.

# How to test
1. Upload a .elp file exported with eXeLearning 3.x (should be accepted and visualized).
2. Upload a .elp file from eXeLearning 2.9 (should be rejected with a helpful message).
3. Upload a standard SCORM package (should work as before).