### PR TITLE
Prevent fork pull requests from running preview workflow

### DIFF
--- a/.github/workflows/pr-playground-preview.yml
+++ b/.github/workflows/pr-playground-preview.yml
@@ -11,6 +11,7 @@ permissions:
 
 jobs:
   preview:
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary

- skip the playground preview job when a pull request originates from a fork
- preserve previews for branches within this repository

## Security rationale

The workflow has pull-request write permission. Restricting it to same-repository branches prevents external contributors from triggering a write-capable workflow.