### PR TITLE
Restore previews for approved fork pull requests

### DIFF
--- a/.github/workflows/pr-playground-preview.yml
+++ b/.github/workflows/pr-playground-preview.yml
@@ -11,7 +11,6 @@ permissions:
 
 jobs:
   preview:
-    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary

- revert the fork-specific preview restriction introduced in #21
- allow the preview workflow to run after GitHub's external-contributor approval gate

## Rationale

The repository or organization should use **Require approval for all external contributors**. This preserves manual approval while allowing maintainers to preview legitimate external contributions.